### PR TITLE
feat: Add Cypress E2E tests

### DIFF
--- a/cypress/e2e/02-citation-view.cy.js
+++ b/cypress/e2e/02-citation-view.cy.js
@@ -1,0 +1,20 @@
+import { slateBeforeEach, slateAfterEach } from '../support/e2e';
+
+describe('Citation Block: View Mode Tests', () => {
+  beforeEach(slateBeforeEach);
+  afterEach(slateAfterEach);
+
+  it('Citation Block: Add and save', () => {
+    cy.clearSlateTitle();
+    cy.getSlateTitle().type('Citation View Test');
+    cy.get('.documentFirstHeading').contains('Citation View Test');
+
+    // Add citation block via slash command
+    cy.getSlate().click().type('/citation{enter}');
+
+    // Save without editing
+    cy.get('#toolbar-save').click();
+
+    cy.contains('Citation View Test');
+  });
+});


### PR DESCRIPTION
Added Cypress E2E test coverage for `volto-citation`. All tests passing on Volto 18.